### PR TITLE
Add pydantic settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,20 @@ The package can be installed from your terminal by typing:
 
     pip install basecampapi
 
-You need to have python 3.7 or higher installed.
+You need to have python 3.8 or higher installed.
+
+### Configuration with environment variables
+
+`BasecampConfig` can load credentials from environment variables using the
+`BASECAMP_` prefix (for example `BASECAMP_ACCOUNT_ID`). You can also define them
+in a `.env` file. Pass an instance of `BasecampConfig` to `Basecamp`:
+
+```python
+from basecampapi import Basecamp, BasecampConfig
+
+config = BasecampConfig()
+bc = Basecamp(credentials=config)
+```
 
 
 ## 2. Initial authentication: Getting your refresh token

--- a/basecampapi/__init__.py
+++ b/basecampapi/__init__.py
@@ -2,3 +2,4 @@ from .basecamp import Basecamp
 from .endpoints.camprife import Campfire
 from .endpoints.messageboard import MessageBoard
 from .endpoints.attachments import Attachments
+from .config import BasecampConfig

--- a/basecampapi/basecamp.py
+++ b/basecampapi/basecamp.py
@@ -1,11 +1,14 @@
 import requests
+from typing import Union
+
+from .config import BasecampConfig
 
 class Basecamp:
     
     __credentials = {}
     __base_url = ""
     
-    def __init__(self, credentials: dict, verification_code='Not available!'):
+    def __init__(self, credentials: Union[dict, BasecampConfig], verification_code='Not available!'):
         '''
         Initializes a Basecamp session.
 
@@ -14,6 +17,9 @@ class Basecamp:
             credentials (dict): A dictionary containing client_id, client_secret, redirect_uri and refresh_token.
         ''' 
         
+        if isinstance(credentials, BasecampConfig):
+            credentials = credentials.model_dump()
+
         Basecamp.__base_url = f"https://3.basecampapi.com/{credentials['account_id']}"
         Basecamp.__credentials = credentials
         

--- a/basecampapi/config.py
+++ b/basecampapi/config.py
@@ -1,0 +1,13 @@
+from pydantic import BaseModel
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+class BasecampConfig(BaseSettings):
+    """Configuration for Basecamp credentials."""
+
+    account_id: int
+    client_id: str
+    client_secret: str
+    redirect_uri: str
+    refresh_token: str | None = None
+
+    model_config = SettingsConfigDict(env_prefix="BASECAMP_", env_file=".env", extra="ignore")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,9 +6,11 @@ authors = ["mare011rs <mare011rs@gmail.com>"]
 readme = "README.md"
 
 [tool.poetry.dependencies]
-python = "^3.7"
+python = "^3.8"
 requests = "*"
 filetype = "^1.2.0"
+pydantic = "^2.0"
+pydantic-settings = "^2.0"
 
 
 [build-system]


### PR DESCRIPTION
## Summary
- add BasecampConfig using pydantic v2 settings
- support the new config in Basecamp
- document env-based configuration
- update dependencies for pydantic v2

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*