### PR TITLE
Add unit tests

### DIFF
--- a/tests/test_attachments.py
+++ b/tests/test_attachments.py
@@ -1,0 +1,56 @@
+import unittest
+from unittest.mock import patch, MagicMock
+import sys
+import types
+
+# Provide minimal stubs so modules import without external packages
+requests_stub = types.ModuleType('requests')
+requests_stub.post = lambda *args, **kwargs: None
+requests_stub.get = lambda *args, **kwargs: None
+sys.modules.setdefault('requests', requests_stub)
+
+filetype_stub = types.ModuleType('filetype')
+filetype_stub.guess = lambda *args, **kwargs: None
+sys.modules.setdefault('filetype', filetype_stub)
+
+from basecampapi import Basecamp, Attachments
+
+class TestAttachments(unittest.TestCase):
+    @patch('filetype.guess')
+    @patch('requests.post')
+    def test_upload_from_bytes(self, mock_post, mock_guess):
+        # mock responses for Basecamp.__get_access and Attachments.upload_from_bytes
+        access_resp = MagicMock()
+        access_resp.ok = True
+        access_resp.json.return_value = {'access_token': 'tok'}
+
+        upload_resp = MagicMock()
+        upload_resp.ok = True
+        upload_resp.json.return_value = {'attachable_sgid': 'sgid123'}
+
+        mock_post.side_effect = [access_resp, upload_resp]
+
+        dummy_type = MagicMock()
+        dummy_type.mime = 'image/png'
+        mock_guess.return_value = dummy_type
+
+        creds = {
+            'account_id': '2',
+            'client_id': 'cid',
+            'client_secret': 'secret',
+            'redirect_uri': 'uri',
+            'refresh_token': 'ref',
+        }
+
+        Basecamp(credentials=creds)
+        att = Attachments()
+        att.upload_from_bytes(b'data', 'img.png')
+
+        self.assertIn('img.png', att.files)
+        info = att.files['img.png']
+        self.assertEqual(info['filename'], 'img.png')
+        self.assertEqual(info['sgid'], 'sgid123')
+        mock_post.assert_called_with(f"https://3.basecampapi.com/2/attachments.json?name=img.png", headers={'Authorization': 'Bearer tok', 'Content-Type': 'image/png', 'Content-Length': '4'}, data=b'data')
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_basecamp.py
+++ b/tests/test_basecamp.py
@@ -1,0 +1,52 @@
+import unittest
+from unittest.mock import patch, MagicMock
+import sys
+import types
+
+# Provide minimal stubs for external dependencies so the library can be imported
+requests_stub = types.ModuleType('requests')
+requests_stub.post = lambda *args, **kwargs: None
+requests_stub.get = lambda *args, **kwargs: None
+sys.modules.setdefault('requests', requests_stub)
+
+from basecampapi import Basecamp
+
+class TestBasecamp(unittest.TestCase):
+    @patch('requests.post')
+    def test_init_with_refresh_token(self, mock_post):
+        # mock access token response
+        mock_response = MagicMock()
+        mock_response.ok = True
+        mock_response.json.return_value = {'access_token': 'token123'}
+        mock_post.return_value = mock_response
+
+        creds = {
+            'account_id': '99',
+            'client_id': 'cid',
+            'client_secret': 'secret',
+            'redirect_uri': 'uri',
+            'refresh_token': 'ref',
+        }
+
+        Basecamp(credentials=creds)
+
+        self.assertEqual(Basecamp._Basecamp__base_url, 'https://3.basecampapi.com/99')
+        self.assertEqual(Basecamp._Basecamp__credentials['access_token'], 'token123')
+        mock_post.assert_called_once()
+
+    @patch('requests.post')
+    def test_init_missing_refresh_token_raises(self, mock_post):
+        creds = {
+            'account_id': '1',
+            'client_id': 'cid',
+            'client_secret': 'secret',
+            'redirect_uri': 'uri',
+        }
+
+        with self.assertRaises(Exception) as ctx:
+            Basecamp(credentials=creds)
+        self.assertIn('Access denied', str(ctx.exception))
+        self.assertTrue(mock_post.called is False)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_messageboard.py
+++ b/tests/test_messageboard.py
@@ -1,0 +1,52 @@
+import unittest
+from unittest.mock import patch, MagicMock
+import sys
+import types
+
+# Provide minimal stubs for external dependencies
+requests_stub = types.ModuleType('requests')
+requests_stub.post = lambda *args, **kwargs: None
+requests_stub.get = lambda *args, **kwargs: None
+sys.modules.setdefault('requests', requests_stub)
+
+from basecampapi import Basecamp, MessageBoard
+
+class TestMessageBoard(unittest.TestCase):
+    @patch('requests.post')
+    @patch('requests.get')
+    def test_create_message(self, mock_get, mock_post):
+        # first post for access token then create message
+        access_resp = MagicMock()
+        access_resp.ok = True
+        access_resp.json.return_value = {'access_token': 'tok'}
+
+        # GET request for initialization of MessageBoard
+        get_resp = MagicMock()
+        get_resp.ok = True
+        get_resp.json.return_value = []
+        mock_get.return_value = get_resp
+
+        post_resp = MagicMock()
+        post_resp.ok = True
+        mock_post.side_effect = [access_resp, post_resp]
+
+        creds = {
+            'account_id': '3',
+            'client_id': 'cid',
+            'client_secret': 'secret',
+            'redirect_uri': 'uri',
+            'refresh_token': 'ref',
+        }
+
+        Basecamp(credentials=creds)
+        board = MessageBoard(project_id=1, message_board_id=2)
+        board.create_message('subj', 'body')
+
+        mock_post.assert_called_with(
+            'https://3.basecampapi.com/3/buckets/1/message_boards/2/messages.json',
+            headers={'Authorization': 'Bearer tok', 'Content-Type': 'application/json'},
+            data='{"subject": "subj", "content": "body", "status": "active"}'
+        )
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- create unittests for `Basecamp`, `Attachments`, and `MessageBoard`
- stub out missing external modules in the tests so import works

## Testing
- `python3 -m unittest discover tests`