### PR TITLE
Add BrowserAuth automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This package allows simple interaction with [Basecamp API](https://github.com/ba
 3. [Authentication with Refresh token](https://github.com/mare011rs/basecampapi#3-authentication-with-refresh-token)
 4. [Attachments](https://github.com/mare011rs/basecampapi#4-attachments)
 5. [Additional information](https://github.com/mare011rs/basecampapi#5-additional-information)
+6. [Browser automation](https://github.com/mare011rs/basecampapi#6-browser-automation)
 
 ## 1. Installation
 The package can be installed from your terminal by typing:
@@ -16,6 +17,9 @@ The package can be installed from your terminal by typing:
     pip install basecampapi
 
 You need to have python 3.7 or higher installed.
+
+If you want to use the ``BrowserAuth`` helper for automated token retrieval,
+install Selenium and have a compatible WebDriver available on your ``PATH``.
 
 
 ## 2. Initial authentication: Getting your refresh token
@@ -160,3 +164,26 @@ Future upgrades:
 - To-dos
 
 Request new features in [issues](https://github.com/mare011rs/basecampapi/issues).
+
+## 6. Browser automation
+
+The `BrowserAuth` utility automates the process of obtaining both access and
+refresh tokens. It relies on Selenium and a local web driver installation.
+
+```python
+from basecampapi import BrowserAuth
+
+creds = {
+    "client_id": "your-client-id",
+    "client_secret": "your-client-secret",
+    "redirect_uri": "http://localhost"
+}
+
+auth = BrowserAuth(creds, username="your-login", password="your-password")
+tokens = auth.get_tokens()
+print(tokens["refresh_token"], tokens["access_token"])
+```
+
+Make sure `chromedriver` or another Selenium compatible driver is installed and
+available on your system's `PATH`.
+

--- a/basecampapi/__init__.py
+++ b/basecampapi/__init__.py
@@ -2,3 +2,4 @@ from .basecamp import Basecamp
 from .endpoints.camprife import Campfire
 from .endpoints.messageboard import MessageBoard
 from .endpoints.attachments import Attachments
+from .browser_auth import BrowserAuth

--- a/basecampapi/browser_auth.py
+++ b/basecampapi/browser_auth.py
@@ -1,0 +1,83 @@
+import time
+from urllib.parse import urlparse, parse_qs
+
+import requests
+from selenium import webdriver
+from selenium.webdriver.common.by import By
+from selenium.webdriver.chrome.options import Options
+
+
+class BrowserAuth:
+    """Automate Basecamp authentication using a browser.
+
+    Parameters
+    ----------
+    credentials : dict
+        Dictionary containing ``client_id``, ``client_secret`` and
+        ``redirect_uri``.
+    username : str
+        Basecamp username.
+    password : str
+        Basecamp password.
+    headless : bool, optional
+        Run browser in headless mode, by default ``True``.
+    """
+
+    def __init__(self, credentials: dict, username: str, password: str, headless: bool = True):
+        self.credentials = credentials
+        self.username = username
+        self.password = password
+        self.headless = headless
+
+    def get_tokens(self) -> dict:
+        """Return refreshed credentials containing ``access_token`` and ``refresh_token``."""
+
+        verification_url = (
+            "https://launchpad.37signals.com/authorization/new?type=web_server"
+            f"&client_id={self.credentials['client_id']}"
+            f"&redirect_uri={self.credentials['redirect_uri']}"
+        )
+
+        options = Options()
+        if self.headless:
+            options.add_argument("--headless")
+
+        # NOTE: Requires a webdriver installed and available on PATH.
+        driver = webdriver.Chrome(options=options)
+
+        try:
+            driver.get(verification_url)
+            # The element identifiers may change, update them if necessary.
+            driver.find_element(By.ID, "username").send_keys(self.username)
+            driver.find_element(By.ID, "password").send_keys(self.password)
+            driver.find_element(By.NAME, "commit").click()
+
+            # Wait for redirection to the provided redirect URI
+            time.sleep(5)
+            redirect_url = driver.current_url
+        finally:
+            driver.quit()
+
+        code_list = parse_qs(urlparse(redirect_url).query).get("code")
+        if not code_list:
+            raise Exception("Could not obtain verification code from redirect URL.")
+        code = code_list[0]
+
+        token_url = (
+            "https://launchpad.37signals.com/authorization/token?type=web_server"
+            f"&client_id={self.credentials['client_id']}"
+            f"&redirect_uri={self.credentials['redirect_uri']}"
+            f"&client_secret={self.credentials['client_secret']}"
+            f"&code={code}"
+        )
+
+        response = requests.post(token_url)
+        if not response.ok:
+            raise Exception(
+                f"Status code: {response.status_code}. {response.reason}. Error text: {response.text}."
+            )
+
+        data = response.json()
+        self.credentials["refresh_token"] = data["refresh_token"]
+        self.credentials["access_token"] = data["access_token"]
+        return self.credentials

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 python = "^3.7"
 requests = "*"
 filetype = "^1.2.0"
+selenium = "*"
 
 
 [build-system]


### PR DESCRIPTION
## Summary
- add `BrowserAuth` utility to automate fetching auth tokens via Selenium
- expose `BrowserAuth` in package exports
- add dependency on Selenium
- document browser automation usage in README
- clarify Selenium requirement in installation section

## Testing
- `python -m py_compile basecampapi/browser_auth.py`
- `python -m py_compile basecampapi/__init__.py`
- `pytest -q` *(fails: command not found)*