### PR TITLE
Add Typer CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ This package allows simple interaction with [Basecamp API](https://github.com/ba
 3. [Authentication with Refresh token](https://github.com/mare011rs/basecampapi#3-authentication-with-refresh-token)
 4. [Attachments](https://github.com/mare011rs/basecampapi#4-attachments)
 5. [Additional information](https://github.com/mare011rs/basecampapi#5-additional-information)
+6. [Command line interface](https://github.com/mare011rs/basecampapi#6-command-line-interface)
+7. [Solution architecture](https://github.com/mare011rs/basecampapi#7-solution-architecture)
 
 ## 1. Installation
 The package can be installed from your terminal by typing:
@@ -160,3 +162,37 @@ Future upgrades:
 - To-dos
 
 Request new features in [issues](https://github.com/mare011rs/basecampapi/issues).
+
+## 6. Command line interface
+
+This package now provides a Typer-powered CLI. After installation you can access
+it with the ``basecampapi`` command:
+
+```bash
+basecampapi --help
+```
+
+The CLI exposes commands for authentication, sending Campfire messages and
+creating Message Board posts. Run ``basecampapi <command> --help`` for details on
+available options.
+
+## 7. Solution architecture
+
+This project follows a modular architecture. The ``Basecamp`` class handles
+authentication and stores session state. Feature-specific endpoint classes such
+as ``Campfire``, ``MessageBoard`` and ``Attachments`` extend ``Basecamp`` to
+interact with their respective API sections. The optional command line interface
+is implemented using Typer and simply invokes these classes under the hood.
+
+```text
+┌───────────────┐      ┌─────────────────────┐
+│   Basecamp    │◀────▶│   Endpoint classes  │
+└───────────────┘      │  (Campfire, etc.)   │
+        ▲              └─────────────────────┘
+        │                   ▲
+        │                   │
+        ▼              ┌─────────┐
+     Typer CLI ───────▶│  User   │
+                       └─────────┘
+```
+

--- a/basecampapi/__init__.py
+++ b/basecampapi/__init__.py
@@ -2,3 +2,4 @@ from .basecamp import Basecamp
 from .endpoints.camprife import Campfire
 from .endpoints.messageboard import MessageBoard
 from .endpoints.attachments import Attachments
+from .cli import app

--- a/basecampapi/cli.py
+++ b/basecampapi/cli.py
@@ -1,0 +1,80 @@
+import typer
+from .basecamp import Basecamp
+from .endpoints.camprife import Campfire
+from .endpoints.messageboard import MessageBoard
+
+app = typer.Typer(help="CLI interface for Basecamp API")
+
+@app.command()
+def auth(
+    account_id: int,
+    client_id: str,
+    client_secret: str,
+    redirect_uri: str,
+    verification_code: str = None,
+):
+    """Authenticate with Basecamp and retrieve access token."""
+    credentials = {
+        "account_id": account_id,
+        "client_id": client_id,
+        "client_secret": client_secret,
+        "redirect_uri": redirect_uri,
+    }
+    if verification_code:
+        typer.echo("Using verification code to obtain refresh token...")
+        Basecamp(credentials=credentials, verification_code=verification_code)
+    else:
+        try:
+            Basecamp(credentials=credentials)
+        except Exception as exc:
+            typer.echo(str(exc))
+
+@app.command()
+def campfire_send(
+    account_id: int,
+    client_id: str,
+    client_secret: str,
+    redirect_uri: str,
+    refresh_token: str,
+    project_id: int,
+    campfire_id: int,
+    content: str,
+):
+    """Send a message to a Campfire chat."""
+    credentials = {
+        "account_id": account_id,
+        "client_id": client_id,
+        "client_secret": client_secret,
+        "redirect_uri": redirect_uri,
+        "refresh_token": refresh_token,
+    }
+    Basecamp(credentials=credentials)
+    campfire = Campfire(project_id=project_id, campfire_id=campfire_id)
+    campfire.write(content=content)
+
+@app.command()
+def message_create(
+    account_id: int,
+    client_id: str,
+    client_secret: str,
+    redirect_uri: str,
+    refresh_token: str,
+    project_id: int,
+    message_board_id: int,
+    subject: str,
+    content: str,
+):
+    """Create a message on a message board."""
+    credentials = {
+        "account_id": account_id,
+        "client_id": client_id,
+        "client_secret": client_secret,
+        "redirect_uri": redirect_uri,
+        "refresh_token": refresh_token,
+    }
+    Basecamp(credentials=credentials)
+    mb = MessageBoard(project_id=project_id, message_board_id=message_board_id)
+    mb.create_message(subject=subject, content=content)
+
+if __name__ == "__main__":
+    app()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,8 +9,12 @@ readme = "README.md"
 python = "^3.7"
 requests = "*"
 filetype = "^1.2.0"
+typer = "^0.7.0"
 
 
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
+
+[tool.poetry.scripts]
+basecampapi = "basecampapi.cli:app"


### PR DESCRIPTION
## Summary
- implement a Typer-based CLI
- expose the CLI in `__init__.py`
- document the new CLI in README
- add `typer` as a dependency and provide a console entry point
- document overall solution architecture

## Testing
- `python -m compileall -q basecampapi tests`
- `python -m unittest tests -v`
